### PR TITLE
Fix Directory not found exception

### DIFF
--- a/CyberdropDownloader/Program.cs
+++ b/CyberdropDownloader/Program.cs
@@ -117,6 +117,7 @@ namespace CyberdropDownloader
                 Regex regex = new Regex(pattern, regexOptions);
                 string inputData = htmlCode;
                 AlbumName = Substring(htmlCode, "<h1 id=\"title\" class=\"title has-text-centered\" title=\"", "\"");
+                AlbumName = string.Concat(AlbumName.Split(Path.GetInvalidFileNameChars()));
                 if (Directory.Exists("Downloads\\" + AlbumName)) continue;
                 Directory.CreateDirectory("Downloads\\" + AlbumName);
                 AlbumPics?.Clear();


### PR DESCRIPTION
If Album name contains invalid path characters it currently throws an exception the directory is not found. This pull request removes invalid path characters from the album name.